### PR TITLE
Add Google OAuth login and admin calendar features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This repository contains a sample full-stack application for an office food orde
 - **Backend:** Node.js, Express.js, MongoDB
 - **Frontend:** React.js, Tailwind CSS
 
-The application demonstrates JWT-based authentication, restaurant scheduling, order placement, and admin reporting features.
+The application demonstrates JWT-based authentication with optional Google OAuth, restaurant scheduling, order placement, and admin reporting features.
 
 Refer to `backend/README.md` and `frontend/README.md` for setup instructions.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,4 @@
 MONGO_URI=mongodb://localhost:27017/office_food
 JWT_SECRET=your_jwt_secret
 PORT=5000
+GOOGLE_CLIENT_ID=your_google_client_id

--- a/backend/README.md
+++ b/backend/README.md
@@ -12,6 +12,7 @@ This is the Express.js backend for the Office Food Ordering System.
 
 - `POST /api/auth/register` – Register user
 - `POST /api/auth/login` – Login and receive JWT
+- `POST /api/auth/google` – Login with Google OAuth
 - `GET /api/restaurants` – List restaurants (auth required)
 - `POST /api/restaurants` – Create restaurant (admin only)
 - `GET /api/calendar/today` – Get today restaurants (auth required)
@@ -20,7 +21,9 @@ This is the Express.js backend for the Office Food Ordering System.
 - `GET /api/orders/mine` – User order history
 - `GET /api/admin/orders` – Admin list orders by day/restaurant
 - `GET /api/admin/orders/export` – Export orders CSV
+- `GET /api/admin/orders/export/excel` – Export orders Excel
 
 ## Exporting Orders
 
 The admin can export orders for a specific day and restaurant using the `/api/admin/orders/export?date=YYYY-MM-DD&restaurantId=...` endpoint. The controller uses `fast-csv` to generate the CSV file.
+For Excel format, hit `/api/admin/orders/export/excel` with the same query parameters.

--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -1,6 +1,6 @@
 const Order = require('../models/Order');
 const Restaurant = require('../models/Restaurant');
-const { exportOrdersCSV } = require('../utils/export');
+const { exportOrdersCSV, exportOrdersExcel } = require('../utils/export');
 
 exports.getOrdersByDay = async (req, res) => {
   const { date, restaurantId } = req.query;
@@ -19,4 +19,15 @@ exports.exportOrders = async (req, res) => {
   res.header('Content-Type', 'text/csv');
   res.attachment('orders.csv');
   return res.send(csv);
+};
+
+exports.exportOrdersExcel = async (req, res) => {
+  const { date, restaurantId } = req.query;
+  const filter = { date: new Date(date) };
+  if (restaurantId) filter['items.restaurant'] = restaurantId;
+  const orders = await Order.find(filter).populate('items.restaurant user');
+  const buffer = await exportOrdersExcel(orders);
+  res.header('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  res.attachment('orders.xlsx');
+  return res.send(buffer);
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,8 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "fast-csv": "^4.3.6",
+    "exceljs": "^4.3.0",
+    "google-auth-library": "^9.0.0",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.0.3"
   },

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -1,10 +1,15 @@
 const express = require('express');
-const { getOrdersByDay, exportOrders } = require('../controllers/adminController');
+const {
+  getOrdersByDay,
+  exportOrders,
+  exportOrdersExcel,
+} = require('../controllers/adminController');
 const { protect, adminOnly } = require('../middleware/auth');
 
 const router = express.Router();
 
 router.get('/orders', protect, adminOnly, getOrdersByDay);
 router.get('/orders/export', protect, adminOnly, exportOrders);
+router.get('/orders/export/excel', protect, adminOnly, exportOrdersExcel);
 
 module.exports = router;

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
-const { register, login } = require('../controllers/authController');
+const { register, login, googleLogin } = require('../controllers/authController');
 
 const router = express.Router();
 
 router.post('/register', register);
 router.post('/login', login);
+router.post('/google', googleLogin);
 
 module.exports = router;

--- a/backend/utils/export.js
+++ b/backend/utils/export.js
@@ -1,5 +1,6 @@
 const csv = require('fast-csv');
 const { Readable } = require('stream');
+const ExcelJS = require('exceljs');
 
 exports.exportOrdersCSV = (orders) => {
   const rows = [];
@@ -23,4 +24,28 @@ exports.exportOrdersCSV = (orders) => {
       .on('end', () => resolve(Buffer.concat(chunks)))
       .on('error', reject);
   });
+};
+
+exports.exportOrdersExcel = async (orders) => {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Orders');
+  sheet.columns = [
+    { header: 'User', key: 'user' },
+    { header: 'Restaurant', key: 'restaurant' },
+    { header: 'Item', key: 'item' },
+    { header: 'Price', key: 'price' },
+    { header: 'Date', key: 'date' },
+  ];
+  orders.forEach((o) => {
+    o.items.forEach((i) => {
+      sheet.addRow({
+        user: o.user.name,
+        restaurant: i.restaurant.name,
+        item: i.item,
+        price: i.price,
+        date: o.date.toISOString().split('T')[0],
+      });
+    });
+  });
+  return workbook.xlsx.writeBuffer();
 };

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_GOOGLE_CLIENT_ID=your_google_client_id

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,7 +4,8 @@ React + Vite + Tailwind front-end for the Office Food Ordering System.
 
 ## Setup
 
-1. Run `npm install`.
-2. Start dev server with `npm run dev`.
+1. Copy `.env.example` to `.env` and set your Google Client ID.
+2. Run `npm install`.
+3. Start dev server with `npm run dev`.
 
 The app expects the backend API to run on `http://localhost:5000`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "@react-oauth/google": "^0.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import OrderHistory from './pages/OrderHistory';
 import AdminOrders from './pages/AdminOrders';
+import AdminCalendar from './pages/AdminCalendar';
 
 function App() {
   return (
@@ -11,13 +12,15 @@ function App() {
       <nav className="p-4 bg-gray-800 text-white flex gap-4">
         <Link to="/">Home</Link>
         <Link to="/history">My Orders</Link>
-        <Link to="/admin">Admin</Link>
+        <Link to="/admin">Admin Orders</Link>
+        <Link to="/admin/calendar">Admin Calendar</Link>
       </nav>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/login" element={<Login />} />
         <Route path="/history" element={<OrderHistory />} />
         <Route path="/admin" element={<AdminOrders />} />
+        <Route path="/admin/calendar" element={<AdminCalendar />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <App />
+    </GoogleOAuthProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/AdminCalendar.jsx
+++ b/frontend/src/pages/AdminCalendar.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+function AdminCalendar() {
+  const [restaurants, setRestaurants] = useState([]);
+  const [date, setDate] = useState('');
+  const [first, setFirst] = useState('');
+  const [second, setSecond] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const token = localStorage.getItem('token');
+      const { data } = await axios.get('http://localhost:5000/api/restaurants', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setRestaurants(data);
+    };
+    load();
+  }, []);
+
+  const save = async () => {
+    const token = localStorage.getItem('token');
+    await axios.post(
+      'http://localhost:5000/api/calendar',
+      { date, restaurants: [first, second] },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+  };
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl mb-4">Set Daily Restaurants</h2>
+      <input
+        type="date"
+        className="border p-2 mb-2"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+      />
+      <div className="mb-2">
+        <select
+          className="border p-2 mr-2"
+          value={first}
+          onChange={(e) => setFirst(e.target.value)}
+        >
+          <option value="">Select first restaurant</option>
+          {restaurants.map((r) => (
+            <option key={r._id} value={r._id}>
+              {r.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border p-2"
+          value={second}
+          onChange={(e) => setSecond(e.target.value)}
+        >
+          <option value="">Select second restaurant</option>
+          {restaurants.map((r) => (
+            <option key={r._id} value={r._id}>
+              {r.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button className="bg-blue-500 text-white p-2" onClick={save}>
+        Save
+      </button>
+    </div>
+  );
+}
+
+export default AdminCalendar;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import { GoogleLogin } from '@react-oauth/google';
 
 function Login() {
   const [email, setEmail] = useState('');
@@ -32,6 +33,18 @@ function Login() {
       <button className="bg-blue-500 text-white p-2" onClick={handleLogin}>
         Login
       </button>
+      <div className="mt-4">
+        <GoogleLogin
+          onSuccess={async (cred) => {
+            const { data } = await axios.post(
+              'http://localhost:5000/api/auth/google',
+              { token: cred.credential }
+            );
+            localStorage.setItem('token', data.token);
+          }}
+          onError={() => console.log('Google Login Failed')}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- support login via Google on the backend and frontend
- add Excel export support and new admin API route
- implement admin calendar page for scheduling restaurants
- wire Google OAuth provider into the frontend
- document new environment variables and setup steps

## Testing
- `npm install` in `backend`
- `npm install` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6849080fb7bc8323af9489f4398cb588